### PR TITLE
Handled errors while creating secureSocket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# PLATFORM
+# ========
+# All exclusions that are specific to the NPM, GIT, IDE and Operating Systems.
+
+# - Do not allow installed node modules to be committed. Doing `npm install -d` will bring them in root or other places.
+node_modules
+
+# - Do not commit any log file from anywhere
+*.log
+*.log.*
+
+# - Prevent addition of OS specific file explorer files
+Thumbs.db
+.DS_Store
+
+# Prevent IDE stuff
+.idea
+.vscode
+
+# PROJECT
+# =======
+# Configuration pertaining to project specific repository structure.
+
+# - Prevent Sublime text IDE files from being commited to repository
+*.sublime-*
+
+# - Allow sublime text project file to be commited in the development directory.
+!/develop/*.sublime-project
+
+# - Prevent CI output files from being Added
+/out/
+
+# - Prevent diff backups from SourceTree from showing as commit.
+*.BACKUP.*
+*.BASE.*
+*.LOCAL.*
+*.REMOTE.*
+*.orig
+
+# - Prevent unit test coverage reports from being committed to the repository
+.coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "tunnel-agent",
+  "version": "0.6.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    }
+  }
+}


### PR DESCRIPTION
**Solves:** https://github.com/postmanlabs/postman-app-support/issues/5916

**What is the problem:**
- Node throws an error while calling `tls.connect()` if given `cert` and `key` do not match. But this error is not handled in `createSecureSocket()` function, causing the process to crash.

**Solution:**
- Wrapped `tls.connect()` in try-catch block to handle the error.
- destroy created socket in case of error and pass the error in callback.
- changed callback arguments to match standard error first convention in node.