### PR TITLE
Bugfix: HTTPS over HTTP with extraCA

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,12 +219,19 @@ function createSecureSocket(options, cb) {
     }
 
     var secureSocket
+    var secureContext
+
+    if(self.options.extraCA) {
+      secureContext = tls.createSecureContext(self.options)
+      secureContext.context.addCACert(self.options.extraCA)
+    }
 
     try {
       // 0 is dummy port for v0.6
       secureSocket = tls.connect(0, mergeOptions({}, self.options,
         { servername: options.host
         , socket: socket
+        , secureContext: secureContext
         }
       ))
     }


### PR DESCRIPTION
Failing certificate validation when tunneling https over http with extraCA attached